### PR TITLE
changes from Joe, Tim and Arjav

### DIFF
--- a/developer-library/multicloud/helidon-verrazzano/build-and-push-app-image/build-and-push-app-image.md
+++ b/developer-library/multicloud/helidon-verrazzano/build-and-push-app-image/build-and-push-app-image.md
@@ -21,7 +21,7 @@ In this lab you will build a Docker image with your Helidon application and push
 
 We'll start by preparing the Docker image that you will use to deploy on Verrazzano.
 
-We are creating a Docker image, which you will upload to Oracle Cloud Container Registry belongs to your OCI account. To do so you need to create image name which reflects your registry coordinates.
+We are creating a Docker image, which you will upload to the Oracle Cloud Container Registry that belongs to your OCI account. To do so you need to create an image name which reflects your registry coordinates.
 
 You need the following information:
 
@@ -136,11 +136,14 @@ In this step, we are going to generate an *Authentication Token*, that we will u
 
 ## Task 3: Push the Helidon Application (quickstart-mp) Docker Image to your Container Registry Repository
 
-In Task 1 of this lab you opened a URL [https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryprerequisites.htm#Availab](https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryprerequisites.htm#Availab) and determined the endpoint for your Region name in a text editor. In our example the Region Name is US East (Ashburn). You will need this information for this task.
+In Task 1 of this lab you opened a URL [https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryprerequisites.htm#Availab](https://docs.oracle.com/en-us/iaas/Content/Registry/Concepts/registryprerequisites.htm#Availab) and determined the endpoint for your Region name and copied it to a text editor. In our example the Region Name is US East (Ashburn). You will need this information for this task.
 
 ![Endpoint](images/5.png)
 
-1. In Task 1 of this lab you determined the endpoint for your Region name and copied it to a text editor. In our example the Region Name is *US East (Ashburn)* and the endpoint is *iad.ocir.io*. You will need this information for this task. Copy the following command and paste it in your text editor and then replace the `END_POINT_OF_REGION_NAME` with the endpoint of your region.
+1. Copy the following command and paste it in your text editor and then replace the `END_POINT_OF_REGION_NAME` with the endpoint of your region.
+
+  >In our example the Region Name is *US East (Ashburn)* and the endpoint is *iad.ocir.io*. You will need your specific information for this task. 
+
 ```bash
 <copy>docker login END_POINT_OF_REGION_NAME</copy>
 ```

--- a/developer-library/multicloud/helidon-verrazzano/deploy-app-on-verrazzano/deploy-app-on-verrazzano.md
+++ b/developer-library/multicloud/helidon-verrazzano/deploy-app-on-verrazzano/deploy-app-on-verrazzano.md
@@ -198,7 +198,7 @@ image: "ocir.io/tenancynamespace/quickstart-mp:1.0"
 
 6. We need to make Verrazzano aware that we store in that namespace Verrazzano artifacts. So we need to add a label identifying the `hello-helidon` namespace as managed by Verrazzano. Labels are intended to be used to specify identifying attributes of objects that are meaningful and relevant to users.
 
-  Here, for the `hello-helidon` namespace, we are attaching a label to it, which marks this namespace as managed by Verrazzano. The *istio-injection=enabled*, enables an Istio "sidecar", and as such, helps establish an Istio proxy. With an Istio proxy, we can access other Istio services like an Istio gateway. To add the label to the bobs-books namespace with the previously mentioned attributes, copy the following command and run it in the Cloud Shell:
+  Here, for the `hello-helidon` namespace, we are attaching a label to it, which marks this namespace as managed by Verrazzano. The *istio-injection=enabled*, enables an Istio "sidecar", and as such, helps establish an Istio proxy. With an Istio proxy, we can access other Istio services like an Istio gateway. To add the label to the `hello-helidon` namespace with the previously mentioned attributes, copy the following command and run it in the Cloud Shell:
 
   ```bash
   <copy>
@@ -206,8 +206,7 @@ image: "ocir.io/tenancynamespace/quickstart-mp:1.0"
   </copy>
   ```
 
-  >We now have a Kuberneter cluster, *cluster1*, with three nodes.
-
+  
 7. Now, we want to deploy Helidon *quickstart-mp* containerized application on *cluster1*. For this, we need a Kubernetes deployment configuration. This deployment instructs the Kubernetes to create and update instances for the Helidon *quickstart-mp* application. Here, we have the `hello-helidon-comp.yaml` file, which instructs Kubernetes.
 
 To deploy the Helidon *quickstart-mp* application, copy and paste the following two commands as shown. The `hello-helidon-comp.yaml` file contains definitions of various OAM components, where, an OAM component is a Kubernetes Custom Resource describing an application’s general composition and environment requirements.

--- a/developer-library/multicloud/helidon-verrazzano/develop-application/develop-application.md
+++ b/developer-library/multicloud/helidon-verrazzano/develop-application/develop-application.md
@@ -64,11 +64,11 @@ PowerShell -Command Invoke-WebRequest -Uri "https://helidon.io/cli/latest/window
 ## Task 2: Create Helidon Greeting Application
 1. In your console enter:
 ```bash
-<copy>helidon init --version 2.3.2</copy>
+<copy>helidon init --version 2.3.2 </copy>
 ```
-> To avoid any potential issues you define specific Helidon version which was tested in this lab's environment.
+> To avoid any potential issues, define the specific Helidon version that was tested for this lab's environment.
 
-2. For this demo we will create *MicroProfile* supported microservice, so choose option **2** for **Helidon Flavor**:
+2. For this demo we will create a MicroProfile supported microservice, so choose option **(2)** for **Helidon MP Flavor**:
 
 ```bash
 Version 2.2.0 of this CLI is now available.
@@ -100,7 +100,7 @@ Switch directory to /Users/mitia/Desktop/quickstart-mp to use CLI
 Start development loop? (Default: n):
 ```
 
->For the **development loop** accept the default (**n**) for now. You will come back to this later.
+>For the **development loop** accept the default (**n**) for now. You will start the development loop later in this lab.
 
 You now have a fully functional Microservice Maven Project:
 
@@ -140,7 +140,13 @@ quickstart-mp
 ```
 
 ## Task 3: Run the Helidon Greeting Application
-From the same console/terminal, navigate to the quickstart-mp directory and run the following two commands:
+From the same console/terminal, navigate to the quickstart-mp directory and run the following commands:
+
+```bash
+<copy> cd quickstart-mp
+</copy>
+```
+
 
 With JDK11+
 ```bash
@@ -194,7 +200,7 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
 
 ```
 
-2. Stop the *quickstart-mp* application by entering 'Ctrl + C' in the terminal where the "java -jar target/quickstart-mp.jar" command is running.
+2. Stop the *quickstart-mp* application by entering `Ctrl + C` in the terminal where the "java -jar target/quickstart-mp.jar" command is running.
 
 ## Task 4: Modify the Application
 
@@ -208,9 +214,9 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
 <copy>helidon dev</copy>
 ```
 
->This will start the *Development loop* mentioned in the previous task.
+>This will start the **Development loop** mentioned in the previous task.
 
-3. Change the property *app.greeting* to "Hello Oracle".
+3. Change the property *app.greeting* to "Hello Oracle" and save the file.
 
 ```properties
 <copy>app.greeting=Hello Oracle</copy>
@@ -218,7 +224,7 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
 
 ![HelidonDev](images/2.jpg)
 
->You will see that whenever you change a file, the **Helidon CLI** recognizes there is a change, recompiles the app, and reruns it. Since Helidon is really small, everything happens really quickly.
+>You will see that whenever you change a file, the **Helidon CLI** recognizes there is a change, recompiles the app, and reruns it. Since Helidon is small, everything happens quickly.
 
 4. In the console/terminal, enter the following:
 
@@ -232,7 +238,7 @@ The result is expected to be:
 {"message":"Hello Oracle World!"}
 ```
 
->Great! You made your first modification.
+Be sure to stop the development loop with `CTRL+C`
 
 5. Go back to your project folder and open the **GreetResource.java** file.
 
@@ -271,13 +277,13 @@ public class GreetHelpResource {
 </copy>
 ```
 
->The class has only one method *getAllGreetings* which returns a list with greetings in different languages. While copying the code, if you encounter an error, then add the necessary package name.
+>The class has only one method *getAllGreetings* which returns a list with greetings in different languages. While copying the code, be sure to add the necessary package name on top of class.
 
 7. Build and run the application:
 
 ```bash
 <copy>
-mvn package
+mvn package -DskipTests
 java -jar target/quickstart-mp.jar
 </copy>
 ```
@@ -300,7 +306,7 @@ curl http://localhost:8080/metrics
 ...
 # TYPE application_me_buzz_mp_quickstart_GreetHelpResource_helpCalled_total counter
 # HELP application_me_buzz_mp_quickstart_GreetHelpResource_helpCalled_total How many time help was called
-application_me_buzz_mp_quickstart_GreetHelpResource_helpCalled_total 3
+application_me_buzz_mp_quickstart_GreetHelpResource_helpCalled_total 1
 ...
 ```
 

--- a/developer-library/multicloud/helidon-verrazzano/install-verrazzano/install-verrazzano.md
+++ b/developer-library/multicloud/helidon-verrazzano/install-verrazzano/install-verrazzano.md
@@ -41,9 +41,9 @@ You will use the *Cloud Shell* to complete this workshop.
 
 We will use `kubectl` to manage the cluster remotely using the Cloud Shell. It needs a `kubeconfig` file. This will be generated using the OCI CLI which is pre-authenticated, so there’s no setup to do before you can start using it.
 
-1. Click *Access Cluster* on your cluster detail page.
+1. Click **Access Cluster** on your cluster detail page.
 
-    > If you moved away from that page, then open the navigation menu and under *Developer Services*, select *Kubernetes Clusters (OKE)*. Select your cluster and go the detail page.
+    > If you moved away from that page, then open the navigation menu and under **Developer Services**, select **Kubernetes Clusters (OKE)**. Select your cluster and go the detail page.
 
     ![Access Cluster](images/1.png)
 
@@ -53,11 +53,13 @@ We will use `kubectl` to manage the cluster remotely using the Cloud Shell. It n
 
     ![Copy kubectl Config](images/2.png)
 
-3. Click **Launch Cloud Shell** to open the built-in console. Close the configuration dialog before you paste the command into the *Cloud Shell*.
+3. Click **Launch Cloud Shell** to open the built-in console. Close the configuration dialog before you paste the command into the Cloud Shell.
 
     ![Launch Cloud Shell](images/3.png)
 
-4. Copy the command from the clipboard and paste it into the Cloud Shell and run the command.
+4. Copy the command from the clipboard and paste it into the local terminal window where you built the `Helidon quickstart` app.
+
+    >Make sure that Docker is installed and running.
 
     For example, the command looks like the following:
 

--- a/developer-library/multicloud/helidon-verrazzano/intro/intro.md
+++ b/developer-library/multicloud/helidon-verrazzano/intro/intro.md
@@ -30,8 +30,8 @@ This lab assumes you have the following installed on your machine:
 
 
 ## About Helidon
-Helidon is a open source microservices framework introduced by Oracle. Helidon is a collection of Java libraries designed for creating lightweight and fast microservices-based applications. The framework supports two programming models for writing microservices: Helidon SE and Helidon MP.
-While Helidon SE is designed to be a microframework that supports the reactive programming model, Helidon is an implementation of the MicroProfile specification. Since MicroProfile has its roots in Java EE, the MicroProfile APIs follow a familiar, declarative approach with heavy use of annotations. This makes it a good choice for Java EE developers.
+Helidon is a open source microservices framework introduced by Oracle that provides a collection of Java libraries designed for creating lightweight and fast microservices-based applications. The framework supports two programming models for writing microservices: Helidon SE and Helidon MP.
+While Helidon SE is designed to be a microframework that supports the reactive programming model, Helidon MP is an implementation of the MicroProfile specification. Since MicroProfile has its roots in Java EE, the MicroProfile APIs follow a familiar, declarative approach with heavy use of annotations. This makes it a good choice for Java EE developers.
 The MicroProfile features aim at the implementation of microservices. You can find APIs for defining REST Clients, monitoring the application, reading technical and functional statistics and for configuring the application.
 Helidon has also  added additional APIs to the core set of Microprofile APIs giving you all the capabilities you need for writing modern cloud native applications.
 


### PR DESCRIPTION
Discussed additional changes with Arjav. Did not make any changes related to Kibana (Lab 6 Task 3). 

I have some feedback from the Helidon team. Let me know if you would like me to include any changes. Hi Lisa, here are a couple comments I had on the lab:
1. In Step 2 the user starts the dev loop. When shoud they exit (Ctrl-C) the dev loop? After Step 4?
2. Step 7: `mvn package` fails because it runs tests and the resource file was modified in Step 3
   and causes a test to fail. Should either be `mvn package -DskipTests` or test needs
   to be modified or resource file change must be changed back or resource file change and dev loop
   moved to end of lab. (edited) 
2:15
From another reviewer: Here are a few observations from working through the Develop Helidon Application part:
Lab 2: Developer Helidon App. 
In task 3, maybe put the `cd quickstart-mp` command into a code block like the other commands. It’s easy to miss embedded in the text.
In task 4, 
maybe emphasize that you need to explicitly save the changed file or (for IntelliJ IDEA’s auto-write feature at least) click into some other window for the IDE to write out the change.
We have left the dev loop running, so there is no need in step 7 to build and run the app again. The dev loop does that for us.
Step 9 - the metrics output will report a total of 1, not 3 as in the example output.

Lisa Jamen  5:04 PM
Some more -
5:04
Hi, again, Lisa. Some more notes… (Sorry the numbering is a bit odd).
Lab 3 - Install V8O
Task 2
Step 1 - operator - I get a warning 
Warning: admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration 
Not a big deal; just not exactly what is in the guide.
Lab 4 - Push Helidon app image
Task 1 - Build Helidon Docker image
Step 4. Instructions are not explicit that the user should paste the revised docker command into the local terminal window where she build the Helidon quickstart app, NOT the cloud shell.
TAsk 3 - Push Helidon app Docker image
Step 2, 2nd bullet: says to paste into Cloud Shell.Shouldn’t this be pasted into local terminal window where the quickstart app is?
Step 7 Maybe be explicit that the command is pasted into the local terminal window, not the Cloud Shell?
Lab 6 - Access and Monitor the app
Task 3 - Explore Kibana
Step 2 -First time in, I see no “Discover” nor a shortcut menu on the left. I click “Explore on my own” to get the screen shown in the on-line guide.
Step 3 - The index verrazzano-namespace-hello-helidon is absent. Only two indices: verrazzano-logstash-2021.09.09 and verraazano-systemd-journal. Same for Safari and Firefox.
Task 5 - Rancher
One I logged in, I get a red pop-up warning: “Error connecting to WebSocket” due to security. It seems it’s due to the way Safari handles the cert. Using Firefox was OK. Maybe suggest to users up front not to use Safari?


Introduction
About Helidon
- Helidon is an implementation of the MicroProfile specification. 
should say Helidon MP 
- may be add a pic like there is one for verrazzano

Lab 2:
Task 4: Modify the Application
Step 5, do we stop helidon dev loop first?
Step 6, clearly say that add package statement on top of class (even without error)
Step 7, we need to fix the MainTest.testHelloWorld as well or revert changes to config file else mvn package fails

Lab 3:
Task 1:
Step 3 can be Step 2
Step 4, have docker installed/running as note/info line
Step 4, 5. is extra in last line of code block

Lab 5:
Task 2:
Step 6, bobs-books should be hello-helidon
Step 6, line "We now have a Kuberneter cluster, cluster1, with three nodes." seems unnecessary

Extra
Add a Lab to clean-up i.e. uninstall vz and delete OKE cluster.